### PR TITLE
Remove Git conflict resolution marker text from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -30,7 +30,3 @@ getYaw					KEYWORD2
 #######################################
 # Constants 			(LITERAL1)
 #######################################
-<<<<<<< HEAD:KEYWORDS.txt
-
-=======
->>>>>>> origin/master:keywords.txt


### PR DESCRIPTION
Some text automatically added by Git during a merge conflict was accidentally committed in https://github.com/xinabox/xSI01/commit/66c9f90e0f74cce6834fad3749314cb8c89b8765.